### PR TITLE
change factory to use extension point

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>variant</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-secretmanager</artifactId>
             <exclusions>

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpCredentialsConverter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpCredentialsConverter.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import java.util.Map;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+
+
+public abstract class GcpCredentialsConverter implements ExtensionPoint {
+
+    public abstract boolean canResolve(String type);
+    public abstract BaseStandardCredentials resolve(String name, Map<String, String> labels, SecretGetter secretGetter);
+
+    public static final ExtensionList<GcpCredentialsConverter> all() {
+        return ExtensionList.lookup(GcpCredentialsConverter.class);
+    }
+
+    @CheckForNull
+    static final GcpCredentialsConverter lookup(String type) {
+        ExtensionList<GcpCredentialsConverter> all = all();
+        for (GcpCredentialsConverter stcc : all) {
+            if (stcc.canResolve(type)) {
+                return stcc;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpCertificateCredentialsConverter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpCertificateCredentialsConverter.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager.converters;
+
+import java.util.Map;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.Extension;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCredentialsConverter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCertificateCredentials;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.SecretGetter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Type;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.CredentialsFactory.SecretBytesSupplier;
+
+@Extension
+public class GcpCertificateCredentialsConverter extends GcpCredentialsConverter {
+
+    @Override
+    public boolean canResolve(String type) {
+        return Type.CERTIFICATE.equals(type);
+    }
+
+    @Override
+    public BaseStandardCredentials resolve(String name, Map<String, String> labels, SecretGetter secretGetter) {
+        return new GcpCertificateCredentials(name, new SecretBytesSupplier(name, secretGetter));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpFileCredentialsConverter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpFileCredentialsConverter.java
@@ -1,0 +1,32 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager.converters;
+
+import java.util.Map;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCredentialsConverter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpFileCredentials;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Labels;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.SecretGetter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Type;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.CredentialsFactory.SecretBytesSupplier;
+
+@OptionalExtension(requirePlugins = { "plain-credentials" })
+public class GcpFileCredentialsConverter extends GcpCredentialsConverter {
+
+    @Override
+    public boolean canResolve(String type) {
+        return Type.FILE.equals(type);
+    }
+
+    @Override
+    public BaseStandardCredentials resolve(String name, Map<String, String> labels, SecretGetter secretGetter) {
+        final String fileExtension = labels.getOrDefault(Labels.FILE_EXTENSION, "");
+        String filename = labels.getOrDefault(Labels.FILENAME, "");
+
+        if (!"".equals(fileExtension)) {
+            filename = filename + "." + fileExtension;
+          }
+
+        return new GcpFileCredentials(name, filename, new SecretBytesSupplier(name, secretGetter));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpSshUserPrivateKeyConverter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpSshUserPrivateKeyConverter.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager.converters;
+
+import java.util.Map;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCredentialsConverter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpSshUserPrivateKey;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Labels;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.SecretGetter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Type;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.CredentialsFactory.SecretSupplier;
+
+@OptionalExtension(requirePlugins={"ssh-credentials"})
+public class GcpSshUserPrivateKeyConverter extends GcpCredentialsConverter {
+
+    @Override
+    public boolean canResolve(String type) {
+        return Type.SSH_USER_PRIVATE_KEY.equals(type);
+    }
+
+    @Override
+    public BaseStandardCredentials resolve(String name, Map<String, String> labels, SecretGetter secretGetter) {
+        final String username = labels.getOrDefault(Labels.USERNAME, "");
+
+        return new GcpSshUserPrivateKey(name, new SecretSupplier(name, secretGetter), username);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpStringCredentialsConverter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpStringCredentialsConverter.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager.converters;
+
+import java.util.Map;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCredentialsConverter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpStringCredentials;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.SecretGetter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Type;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.CredentialsFactory.SecretSupplier;
+
+@OptionalExtension(requirePlugins = { "plain-credentials" })
+public class GcpStringCredentialsConverter extends GcpCredentialsConverter {
+
+    @Override
+    public boolean canResolve(String type) {
+        return Type.STRING.equals(type);
+    }
+
+    @Override
+    public BaseStandardCredentials resolve(String name, Map<String, String> labels, SecretGetter secretGetter) {
+        return new GcpStringCredentials(name, new SecretSupplier(name, secretGetter));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpUsernamePasswordCredentialsConverter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/converters/GcpUsernamePasswordCredentialsConverter.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager.converters;
+
+import java.util.Map;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.Extension;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCredentialsConverter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpUsernamePasswordCredentials;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Labels;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.SecretGetter;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.Type;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.CredentialsFactory.SecretSupplier;
+
+@Extension
+public class GcpUsernamePasswordCredentialsConverter extends GcpCredentialsConverter {
+
+    @Override
+    public boolean canResolve(String type) {
+        return Type.USERNAME_PASSWORD.equals(type);
+    }
+
+    @Override
+    public BaseStandardCredentials resolve(String name, Map<String, String> labels, SecretGetter secretGetter) {
+        final String username = labels.getOrDefault(Labels.USERNAME, "");
+
+        return new GcpUsernamePasswordCredentials(name, new SecretSupplier(name, secretGetter), username);
+    }
+}


### PR DESCRIPTION
I hope you will consider the following change, the motivation behind it is to allow for other plugins to define new credential types. 

The changes are ~~copy-pasted~~ inspired by the factory implementation from [jenkinsci/kubernetes-credentials-provider-plugin](https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/tree/master/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider) which uses extension points, so other plugins can define new credential types, like: [jenkinsci/bitbucket-kubernetes-credentials-plugin](https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin)

- Added abstract class `GcpCredentialsConverter` which implements the extension point, this is the base for the credentials.
- The factory method has been changed to find classes which is derived from `GcpCredentialsConverter`.
- A converter has added for each existing credential type.
- The methods `SecretBytesSupplier` and `SecretSupplier` has been marked as public to make them available to the converters.
- I have not added any additional tests, but instead relied on the existing factory tests to pass

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
