### PR TITLE
add server-side filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,26 @@ Where the secret was created with the following command:
 kubectl create secret generic gcp-sa-secret --from-file=/tmp/sa.json
 ```
 
-### Filtering
+### Client Side Filtering
 
 If you are sharing a GCP project across multiple Jenkins instances, you can use the filtering feature to control which
 secrets get added to the credential store. This feature allows you to specify a custom label and value(s) that each 
-secret must have in order to be added to the store. Note that Jenkins will still need IAM permissions to list and get all other secrets - 
-GCP Secrets Manager does not currently support "server-side" filtering.
+secret must have in order to be added to the store. Note that Jenkins will still need IAM permissions to list and get all other secrets.
 
 You can use a comma-separated string for the label value, which will tell Jenkins to add the secret to the store
 if it matches any of the provided values.
+
+### Server Side Filtering
+
+Server side filtering allows to filter on several properties, a list of Learn more about [Secret Manager server-side filtering in the documentation](https://cloud.google.com/secret-manager/docs/filtering).
+
+Examples:  
+_Retrive only secrets with the label of the value production_
+
+```
+labels.environment:production
+```
+
 
 ### JCasC
 
@@ -258,8 +269,6 @@ node {
 
 * Labels must contain only hyphens (-), underscores (_), lowercase characters, and numbers. Any usernames or 
 filenames in labels that have other characters will not be allowed.
-
-* The secret manager API does not support server-side filtering. 
 
 * The secret manager API does not support descriptions. The description of the secret will be the 
 same as the id.

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>15.0.0</version>
+                <version>23.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -119,6 +119,11 @@
                     <artifactId>jackson2-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/CredentialsSupplier.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/CredentialsSupplier.java
@@ -6,9 +6,13 @@ import com.google.cloud.secretmanager.v1.ListSecretsRequest;
 import com.google.cloud.secretmanager.v1.ProjectName;
 import com.google.cloud.secretmanager.v1.Secret;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.ListSecretsRequest.Builder;
+
 import io.jenkins.plugins.credentials.gcp.secretsmanager.config.Filter;
 import io.jenkins.plugins.credentials.gcp.secretsmanager.config.Messages;
 import io.jenkins.plugins.credentials.gcp.secretsmanager.config.PluginConfiguration;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.config.ServerSideFilter;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +35,7 @@ public class CredentialsSupplier implements Supplier<Collection<StandardCredenti
     PluginConfiguration configuration = PluginConfiguration.getInstance();
     String projectId = configuration.getProject();
     Filter filter = configuration.getFilter();
+    ServerSideFilter serverSideFilter = configuration.getServerSideFilter();
 
     String[] filters = new String[0];
 
@@ -43,8 +48,16 @@ public class CredentialsSupplier implements Supplier<Collection<StandardCredenti
     }
 
     try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
-      ListSecretsRequest listSecretsRequest =
-          ListSecretsRequest.newBuilder().setParent(ProjectName.of(projectId).toString()).build();
+      ListSecretsRequest listSecretsRequest;
+      
+      Builder builder = 
+        ListSecretsRequest.newBuilder().setParent(ProjectName.of(projectId).toString());
+      
+      if (serverSideFilter != null && serverSideFilter.getFilter() != null ) {
+        builder.setFilter(serverSideFilter.getFilter());
+      }
+            
+      listSecretsRequest = builder.build();
 
       SecretManagerServiceClient.ListSecretsPagedResponse secrets =
           client.listSecrets(listSecretsRequest);

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/config/PluginConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/config/PluginConfiguration.java
@@ -13,6 +13,7 @@ public class PluginConfiguration extends GlobalConfiguration {
 
   private String project;
   private Filter filter;
+  private ServerSideFilter serverSideFilter;
 
   public PluginConfiguration() {
     load();
@@ -44,10 +45,22 @@ public class PluginConfiguration extends GlobalConfiguration {
     save();
   }
 
+  public ServerSideFilter getServerSideFilter() {
+    return serverSideFilter;
+  }
+
+  @DataBoundSetter
+  @SuppressWarnings("unused")
+  public void setServerSideFilter(ServerSideFilter serverSideFilter) {
+    this.serverSideFilter = serverSideFilter;
+    save();
+  }
+
   @Override
   public synchronized boolean configure(StaplerRequest req, JSONObject json) {
     this.project = null;
     this.filter = null;
+    this.serverSideFilter = null;
 
     req.bindJSON(this, json);
     save();

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.credentials.gcp.secretsmanager.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class ServerSideFilter extends AbstractDescribableImpl<ServerSideFilter> implements Serializable {
+
+    private String filter;
+
+    @DataBoundConstructor
+    public ServerSideFilter(String filter) {
+        this.filter = filter;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    @DataBoundSetter
+    @SuppressWarnings("unused")
+    public void setLabel(String filter) {
+        this.filter = filter;
+    }
+
+    @Extension
+    @Symbol("serversidefilter")
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<ServerSideFilter> {
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Server-side Filter";
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/PluginConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/PluginConfiguration/config.jelly
@@ -5,5 +5,6 @@
             <f:textbox/>
         </f:entry>
         <f:optionalProperty field="filter" title="${%Filter}" />
+        <f:optionalProperty field="serverSideFilter" title="${%Server-side Filtering}" />
     </f:section>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:entry field="filter" title="${%Filter}">
+        <f:textbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter/help-label.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter/help-label.html
@@ -1,0 +1,3 @@
+<p>
+  The key of the label on the secret to use for filtering.
+</p>

--- a/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter/help-value.html
+++ b/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/ServerSideFilter/help-value.html
@@ -1,0 +1,8 @@
+<p>
+  The value of the label on the secret to use for filtering.
+</p>
+
+<p>
+  To filter by multiple values, use a comma-separated string of values. If the secret matches
+  <b>any</b> of the provided values, the secret will be added to the credential store.
+</p>

--- a/src/test/resources/configuration-as-code.yml
+++ b/src/test/resources/configuration-as-code.yml
@@ -3,4 +3,6 @@ unclassified:
     filter:
       label: "my-label"
       value: "my-value"
+    serverSideFilter:
+      filter: "name:mysecret"
     project: "gcp-project"


### PR DESCRIPTION
This adds the [recently introduced server-side filtering](https://cloud.google.com/blog/products/identity-security/google-cloud-secret-manager-adds-free-of-charge-tier-and-more), please do note **the feature is as of 4 October 2021 still in preview.**

I am not well versed in maven or java dependency management, and I had to update `pom.xml` with com.google.cloud libraries-bom to included filtering, which required the addition of `commons-codec` version 1.15, this will certainly need a keen eye. 

It might be worth considering adding `labels.jenkins-credentials-type:*` or `labels.jenkins-credentials-type:* AND` as a default placeholder entry for server side filtering, or even `labels.jenkins-credentials-type:* AND` in the `CredentialsSupplier.java` by default and then concatenating the user provided filter to limit the payload.

- [Filtering lists of Secrets and Secret Versions documentation](https://cloud.google.com/secret-manager/docs/filtering)

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
