### PR TITLE
fix: Use fingerprint icon from core

### DIFF
--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpSshUserPrivateKey.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpSshUserPrivateKey.java
@@ -58,7 +58,7 @@ public class GcpSshUserPrivateKey extends BaseStandardCredentials implements SSH
 
     @Override
     public String getIconClassName() {
-      return "icon-ssh-credentials-ssh-key";
+      return "icon-fingerprint";
     }
   }
 }


### PR DESCRIPTION
The change proposed utilizes the corresponding icon from core, which respects themes properly.
Current implementation on dark mode:
![Bildschirmfoto 2022-06-23 um 00 36 29](https://user-images.githubusercontent.com/13383509/175166302-c4e6c83c-7a75-44fe-9f30-02dc9d3d0e20.png)
Proposed change:
![Bildschirmfoto 2022-06-23 um 00 39 23](https://user-images.githubusercontent.com/13383509/175166311-99a232be-b9bb-4a7e-a176-b889ca25ae53.png)

cc @tylrd  
