### PR TITLE
Added support for specifying multiple GCP projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ creating and updating secrets.
 ## Usage
 
 To enable the plugin, go to "Configure System" and find the "GCP Secrets Manager" section.
-Input the name of the GCP project that contain the secrets.
+Input the name of the GCP projects that contain the secrets.
 
 Secret names (not values) are cached in-memory for 5 minutes. This is not currently configurable.
 
@@ -45,7 +45,7 @@ At minimum, give Jenkins an IAM role with the following permissions:
 The easiest option is to give the Jenkins service account the pre-built roles `roles/secretmanager.secretAccessor` and 
 `roles/secretmanager.viewer` at the project-level.
 
-Jenkins will attempt to list all secrets for the configured project. If it doesn't have access to list secrets in the project,
+Jenkins will attempt to list all secrets for the configured projects. If it doesn't have access to list secrets in the projects,
 no secrets will be added to the credential store.
 
 If you are running Jenkins on GCP, attach a [default service account](https://cloud.google.com/iam/docs/service-accounts#default)
@@ -115,7 +115,7 @@ unclassified:
     filter:
       label: "my-label"
       value: "my-value-1,my-value-2"
-    project: "my-gcp-project"
+    project: "my-gcp-project1,my-gcp-project2"
 ```
 
 ## Examples

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/CredentialsSupplier.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/CredentialsSupplier.java
@@ -29,51 +29,58 @@ public class CredentialsSupplier implements Supplier<Collection<StandardCredenti
   @Override
   public Collection<StandardCredentials> get() {
     PluginConfiguration configuration = PluginConfiguration.getInstance();
-    String projectId = configuration.getProject();
+    String project = configuration.getProject();
     Filter filter = configuration.getFilter();
 
+    String[] projectIds = new String[0];
     String[] filters = new String[0];
 
     if (filter != null && filter.getValue() != null) {
       filters = filter.getValue().split(",");
     }
 
-    if (projectId == null || "".equals(projectId)) {
+    if (project == null || "".equals(project)) {
       return Collections.emptyList();
+    } else {
+      projectIds = project.split(",");
     }
 
     try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
-      ListSecretsRequest listSecretsRequest =
-          ListSecretsRequest.newBuilder().setParent(ProjectName.of(projectId).toString()).build();
-
-      SecretManagerServiceClient.ListSecretsPagedResponse secrets =
-          client.listSecrets(listSecretsRequest);
-
       final Collection<StandardCredentials> credentials = new ArrayList<>();
 
-      for (Secret secret : secrets.iterateAll()) {
-        Map<String, String> labelsMap = secret.getLabelsMap();
+      for (String projectId : projectIds) {
+        projectId = projectId.trim();
 
-        if (filter != null && filter.getLabel() != null && filter.getValue() != null) {
-          final String matchingLabel = filter.getLabel();
+        ListSecretsRequest listSecretsRequest =
+            ListSecretsRequest.newBuilder().setParent(ProjectName.of(projectId).toString()).build();
 
-          if (labelsMap.containsKey(matchingLabel)) {
-            final String labelValue = labelsMap.get(matchingLabel);
+        SecretManagerServiceClient.ListSecretsPagedResponse secrets =
+            client.listSecrets(listSecretsRequest);
 
-            if (!matchesLabel(labelValue, filters)) {
+        for (Secret secret : secrets.iterateAll()) {
+          Map<String, String> labelsMap = secret.getLabelsMap();
+
+          if (filter != null && filter.getLabel() != null && filter.getValue() != null) {
+            final String matchingLabel = filter.getLabel();
+
+            if (labelsMap.containsKey(matchingLabel)) {
+              final String labelValue = labelsMap.get(matchingLabel);
+
+              if (!matchesLabel(labelValue, filters)) {
+                continue;
+              }
+            } else {
               continue;
             }
-          } else {
-            continue;
           }
-        }
 
-        if (labelsMap.containsKey(Labels.TYPE.toLowerCase())) {
-          final String secretName = secret.getName();
-          final String name = secretName.substring(secretName.lastIndexOf("/") + 1);
-          final Map<String, String> labels = secret.getLabelsMap();
-          CredentialsFactory.create(name, labels, new GcpSecretGetter(projectId))
-              .ifPresent(credentials::add);
+          if (labelsMap.containsKey(Labels.TYPE.toLowerCase())) {
+            final String secretName = secret.getName();
+            final String name = secretName.substring(secretName.lastIndexOf("/") + 1);
+            final Map<String, String> labels = secret.getLabelsMap();
+            CredentialsFactory.create(name, labels, new GcpSecretGetter(projectId))
+                .ifPresent(credentials::add);
+          }
         }
       }
 

--- a/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/PluginConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/credentials/gcp/secretsmanager/config/PluginConfiguration/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:section title="${%GCP Secret Manager}">
-       <f:entry field="project" title="${%GCP Project}">
+       <f:entry field="project" title="${%GCP Projects}">
             <f:textbox/>
         </f:entry>
         <f:optionalProperty field="filter" title="${%Filter}" />


### PR DESCRIPTION
This adds possibility to use multiple GCP projects for fetch secrets from.
It's enough to simply specify all projects separated by `,` (comma) symbol.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
