### PR TITLE
Credentials of `string` type are can be used in string interpolation within JCasC YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GCP Secrets Manager Credentials Provider Plugin](https://img.shields.io/jenkins/plugin/v/gcp-secrets-manager-credentials-provider?style=flat-square)](https://plugins.jenkins.io/gcp-secrets-manager-credentials-provider/)
 
-Access credentials from [Google Cloud Secrets Manager](https://cloud.google.com/secret-manager) in your Jenkins jobs.
+Access credentials from [Google Cloud Secrets Manager](https://cloud.google.com/secret-manager) in your Jenkins jobs and your Configuration as Code files.
 
 ## Setup
 
@@ -131,6 +131,8 @@ unclassified:
       value: "my-value-1,my-value-2"
     project: "my-gcp-project1,my-gcp-project2"
 ```
+
+Secrets of type `string` are available for string interpolation within JCasC YAML files. Use `${SECRETNAME}` within a string in a YAML file to get the value of the corresponding secret. See [the Secret Source documentation of JCasC](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#secret-sources) for more information.
 
 ## Examples
 

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpCredentialsProvider.java
@@ -57,6 +57,10 @@ public class GcpCredentialsProvider extends CredentialsProvider {
     return object == Jenkins.get() ? gcpCredentialsStore : null;
   }
 
+  public Supplier<Collection<StandardCredentials>> getSupplier() {
+    return credentialsSupplier;
+  }
+
   @Override
   public String getIconClassName() {
     return "icon-gcp-secrets-manager-credentials-store";

--- a/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpSecretSource.java
+++ b/src/main/java/io/jenkins/plugins/credentials/gcp/secretsmanager/GcpSecretSource.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.casc.secretsmanager;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.Extension;
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.SecretSource;
+import io.jenkins.plugins.credentials.gcp.secretsmanager.GcpCredentialsProvider;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+@Extension
+public class GcpSecretSource extends SecretSource {
+
+  private static final Logger LOGGER = Logger.getLogger(GcpSecretSource.class.getName());
+
+  @Override
+  public Optional<String> reveal(String id) throws IOException {
+
+    // GcpCredentialsProvider contains logic for fetching secrets from GCP's Secret Manager
+    //   as well as caching results locally
+    // Since GcpSecretSource and GcpCredentialsProvider are initialized separately,
+    //   there is no good way to inject the dependency from one to the other;
+    //   instead, we assume that Jenkins core initializes GcpCredentialsProvider before GcpSecretSource
+    //   and rely on ExtensionList to locate the GcpCredentialsProvider
+    GcpCredentialsProvider gcpCredentialsProvider = ExtensionList.lookupSingleton(GcpCredentialsProvider.class);
+
+    final Collection<StandardCredentials> credentials = gcpCredentialsProvider.getSupplier().get();
+    if (credentials == null) {
+        LOGGER.info("No credentials found, skipping jcasc secret resolution");
+        return Optional.empty();
+    }
+
+    for (StandardCredentials credential : credentials) {
+      if (credential.getId().equals(id)) {
+
+        // For the time being, we only support accessing "Secret text" type credentials
+        if (credential instanceof StringCredentials) {
+          LOGGER.fine("The requested credential " + credential.getId() + " exists in GCP Credentials Provider, and is of type " + credential.getClass().getName());
+          return Optional.ofNullable(((StringCredentials) credential).getSecret().getPlainText());
+        } else {
+          LOGGER.warning("The requested credential " + credential.getId() + " exists in GCP Credentials Provider, but is of type " + credential.getClass().getName() + " which is not supported by GcpSecretSource; we do not return any result");
+          return Optional.empty();
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [~] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

This is an implementation of the SecretSource API. It allows JCasC users to reference `string` type secrets within YAML files by `${SECRETNAME}`.

The SecretSource API is implemented for [a couple of other secrets managers](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#secret-sources) already. This change brings GCP on par with AWS, Azure, K8s and HashiCorp Vault.

The implementation is modelled after the [AWS Secrets Manager Secret Source plugin](https://github.com/jenkinsci/aws-secrets-manager-secret-source-plugin/blob/main/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java). While that is a stand-alone plugin (separate from the [AWS Secrets Manager Credential Provider plugin](https://plugins.jenkins.io/aws-secrets-manager-credentials-provider/)), writing this as a separate implementation would have required duplicating a lot of logic from the Credentials Provider plugin into the new plugin. Therefore I have chosen to implement this into the existing plugin instead.

I have not created any tests. The current plugin doesn't include many tests; I don't know how to structure tests without something to go on.

I am only mapping the `string` type for now. It would be possible to map all other types except `username-password` in a natural way (username-password would turn into a pair; how should that be expanded?). I don't know how you feel about that.

Is this a candidate for accepting to the official plugin?